### PR TITLE
Fix Corner zoom Bug when starting from Intent.

### DIFF
--- a/library/src/com/sigseg/android/map/ImageViewerActivity.java
+++ b/library/src/com/sigseg/android/map/ImageViewerActivity.java
@@ -76,6 +76,13 @@ public class ImageViewerActivity extends Activity {
             imageSurfaceView.setViewportCenter();
         }
     }
+    
+     @Override
+	protected void onResume() {
+		super.onResume();
+		
+		imageSurfaceView.setViewport(new Point(imageSurfaceView.getWidth()/2, imageSurfaceView.getHeight()/2));
+	}
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {


### PR DESCRIPTION
I start the app with:

Intent intent = new Intent(this, ImageViewerActivity.class);
            intent.setAction(android.content.Intent.ACTION_VIEW);
            intent.setDataAndType(Uri.fromFile(new File(info.getLocation())), "image/png");
            startActivity(intent);  

However, there is a corner zoom bug which goes away after the user pans or zooms for the first time.  To fix this.  The suggested code fixes the problem.
