### PR TITLE
Paint screen black before refresh.

### DIFF
--- a/library/src/com/sigseg/android/view/Scene.java
+++ b/library/src/com/sigseg/android/view/Scene.java
@@ -424,6 +424,9 @@ public abstract class Scene {
         void loadBitmapIntoViewport(Bitmap bitmap){
             if (bitmap!=null){
                 synchronized(viewport){
+                     
+                    c.drawColor(Color.BLACK);
+                     
                     int left   = viewport.window.left - window.left;
                     int top    = viewport.window.top  - window.top;
                     int right  = left + viewport.window.width();


### PR DESCRIPTION
This eliminates some artifacts caused by drawing on top of the previous image.  
The sampler drawer can have this line as well.
